### PR TITLE
Add cheerio-based crawler for KBO top players

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "axios": "^1.10.0",
     "dotenv": "^17.0.0",
-    "playwright": "^1.53.1"
+    "playwright": "^1.53.1",
+    "cheerio": "^1.0.0-rc.12"
   }
 }

--- a/src/rankings/firstPlaceCrawler.ts
+++ b/src/rankings/firstPlaceCrawler.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+
+export interface PlayerInfo {
+  name: string;
+  team: string;
+  stat: string;
+}
+
+export interface TopPlayers {
+  battingAvg: PlayerInfo | null;
+  homeRun: PlayerInfo | null;
+  era: PlayerInfo | null;
+  win: PlayerInfo | null;
+}
+
+export async function fetchTopPlayersCheerio(): Promise<TopPlayers> {
+  const url = 'https://www.koreabaseball.com/Record/Ranking/Top5.aspx';
+  const { data } = await axios.get(url);
+  const $ = cheerio.load(data);
+
+  const extract = (box: cheerio.Cheerio): PlayerInfo | null => {
+    if (!box || !box.length) return null;
+    const name = box.find('.player').text().trim();
+    const team = box.find('.team').text().trim();
+    const stat = box.find('.record').text().trim();
+    return { name, team, stat };
+  };
+
+  const hitterBoxes = $('.hitter_ranking .top5');
+  const pitcherBoxes = $('.pitcher_ranking .top5');
+
+  return {
+    battingAvg: extract(hitterBoxes.eq(0)),
+    homeRun: extract(hitterBoxes.eq(1)),
+    era: extract(pitcherBoxes.eq(0)),
+    win: extract(pitcherBoxes.eq(1)),
+  };
+}


### PR DESCRIPTION
## Summary
- add a crawler that scrapes the first place players for batting average, home run, ERA, and wins using axios + cheerio
- register `cheerio` as a dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6861cf670bfc832eb8d913e135f428cf